### PR TITLE
all: add auth type token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG AGOLAWEB_IMAGE="agola-web"
+ARG AGOLAWEB_IMAGE="sorintlab/agola-web:v0.4.0"
 
 FROM $AGOLAWEB_IMAGE as agola-web
 

--- a/cmd/agola/cmd/remotesourcecreate.go
+++ b/cmd/agola/cmd/remotesourcecreate.go
@@ -40,6 +40,7 @@ type remoteSourceCreateOptions struct {
 	name                string
 	rsType              string
 	authType            string
+	authToken           string
 	apiURL              string
 	skipVerify          bool
 	oauth2ClientID      string
@@ -58,6 +59,7 @@ func init() {
 	flags.StringVarP(&remoteSourceCreateOpts.name, "name", "n", "", "remotesource name")
 	flags.StringVar(&remoteSourceCreateOpts.rsType, "type", "", "remotesource type")
 	flags.StringVar(&remoteSourceCreateOpts.authType, "auth-type", "", "remote source auth type")
+	flags.StringVar(&remoteSourceCreateOpts.authToken, "auth-token", "", "remote source auth token")
 	flags.StringVar(&remoteSourceCreateOpts.apiURL, "api-url", "", `remotesource api url (when type is "github" defaults to "https://api.github.com")`)
 	flags.BoolVarP(&remoteSourceCreateOpts.skipVerify, "skip-verify", "", false, "skip remote source api tls certificate verification")
 	flags.StringVar(&remoteSourceCreateOpts.oauth2ClientID, "clientid", "", "remotesource oauth2 client id")
@@ -103,6 +105,7 @@ func remoteSourceCreate(cmd *cobra.Command, args []string) error {
 		Name:                remoteSourceCreateOpts.name,
 		Type:                remoteSourceCreateOpts.rsType,
 		AuthType:            remoteSourceCreateOpts.authType,
+		AuthToken:           remoteSourceCreateOpts.authToken,
 		APIURL:              remoteSourceCreateOpts.apiURL,
 		SkipVerify:          remoteSourceCreateOpts.skipVerify,
 		Oauth2ClientID:      remoteSourceCreateOpts.oauth2ClientID,

--- a/internal/services/common/gitsource.go
+++ b/internal/services/common/gitsource.go
@@ -56,7 +56,7 @@ func newGithub(rs *cstypes.RemoteSource, accessToken string) (*github.Client, er
 
 func GetAccessToken(rs *cstypes.RemoteSource, userAccessToken, oauth2AccessToken string) (string, error) {
 	switch rs.AuthType {
-	case cstypes.RemoteSourceAuthTypePassword:
+	case cstypes.RemoteSourceAuthTypePassword, cstypes.RemoteSourceAuthTypeToken:
 		return userAccessToken, nil
 	case cstypes.RemoteSourceAuthTypeOauth2:
 		return oauth2AccessToken, nil
@@ -99,6 +99,8 @@ func GetUserSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.User
 		userSource, err = GetOauth2Source(rs, accessToken)
 	case cstypes.RemoteSourceAuthTypePassword:
 		userSource, err = GetPasswordSource(rs, accessToken)
+	case cstypes.RemoteSourceAuthTypeToken:
+		userSource, err = GetTokenSource(rs, accessToken)
 	default:
 		return nil, errors.Errorf("unknown remote source auth type")
 	}
@@ -134,4 +136,17 @@ func GetPasswordSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.
 	}
 
 	return passwordSource, err
+}
+
+func GetTokenSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.UserSource, error) {
+	var userSource gitsource.UserSource
+	var err error
+	switch rs.Type {
+	case cstypes.RemoteSourceTypeGitea:
+		userSource, err = newGitea(rs, accessToken)
+	default:
+		return nil, errors.Errorf("remote source %s isn't a valid oauth2 source", rs.Name)
+	}
+
+	return userSource, err
 }

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -51,6 +51,7 @@ type CreateRemoteSourceRequest struct {
 	SkipVerify          bool
 	Type                string
 	AuthType            string
+	AuthToken           string
 	Oauth2ClientID      string
 	Oauth2ClientSecret  string
 	SSHHostKey          string
@@ -99,6 +100,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateRemot
 		Name:                req.Name,
 		Type:                cstypes.RemoteSourceType(req.Type),
 		AuthType:            cstypes.RemoteSourceAuthType(req.AuthType),
+		AuthToken:           req.AuthToken,
 		APIURL:              req.APIURL,
 		SkipVerify:          req.SkipVerify,
 		Oauth2ClientID:      req.Oauth2ClientID,

--- a/internal/services/gateway/action/user.go
+++ b/internal/services/gateway/action/user.go
@@ -584,6 +584,19 @@ func (h *ActionHandler) HandleRemoteSourceAuth(ctx context.Context, remoteSource
 			Response: cres.Response,
 		}, nil
 
+	case cstypes.RemoteSourceAuthTypeToken:
+		requestj, err := json.Marshal(req)
+		if err != nil {
+			return nil, err
+		}
+		cres, err := h.HandleRemoteSourceAuthRequest(ctx, requestType, string(requestj), rs.AuthToken, "", "", time.Time{})
+		if err != nil {
+			return nil, err
+		}
+		return &RemoteSourceAuthResponse{
+			Response: cres.Response,
+		}, nil
+
 	default:
 		return nil, errors.Errorf("unknown remote source authentication type: %q", rs.AuthType)
 	}

--- a/internal/services/gateway/api/remotesource.go
+++ b/internal/services/gateway/api/remotesource.go
@@ -53,6 +53,7 @@ func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		APIURL:              req.APIURL,
 		Type:                req.Type,
 		AuthType:            req.AuthType,
+		AuthToken:           req.AuthToken,
 		SkipVerify:          req.SkipVerify,
 		Oauth2ClientID:      req.Oauth2ClientID,
 		Oauth2ClientSecret:  req.Oauth2ClientSecret,

--- a/services/configstore/types/types.go
+++ b/services/configstore/types/types.go
@@ -154,6 +154,7 @@ type RemoteSourceAuthType string
 const (
 	RemoteSourceAuthTypePassword RemoteSourceAuthType = "password"
 	RemoteSourceAuthTypeOauth2   RemoteSourceAuthType = "oauth2"
+	RemoteSourceAuthTypeToken    RemoteSourceAuthType = "token"
 )
 
 type RemoteSource struct {
@@ -168,8 +169,9 @@ type RemoteSource struct {
 
 	SkipVerify bool `json:"skip_verify,omitempty"`
 
-	Type     RemoteSourceType     `json:"type,omitempty"`
-	AuthType RemoteSourceAuthType `json:"auth_type,omitempty"`
+	Type      RemoteSourceType     `json:"type,omitempty"`
+	AuthType  RemoteSourceAuthType `json:"auth_type,omitempty"`
+	AuthToken string               `json:"auth_token,omitempty"`
 
 	// Oauth2 data
 	Oauth2ClientID     string `json:"client_id,omitempty"`
@@ -205,7 +207,11 @@ func (rs *RemoteSource) UnmarshalJSON(b []byte) error {
 func SourceSupportedAuthTypes(rsType RemoteSourceType) []RemoteSourceAuthType {
 	switch rsType {
 	case RemoteSourceTypeGitea:
-		return []RemoteSourceAuthType{RemoteSourceAuthTypeOauth2, RemoteSourceAuthTypePassword}
+		return []RemoteSourceAuthType{
+			RemoteSourceAuthTypeOauth2,
+			RemoteSourceAuthTypePassword,
+			RemoteSourceAuthTypeToken,
+		}
 	case RemoteSourceTypeGithub:
 		fallthrough
 	case RemoteSourceTypeGitlab:

--- a/services/gateway/api/types/remotesource.go
+++ b/services/gateway/api/types/remotesource.go
@@ -19,6 +19,7 @@ type CreateRemoteSourceRequest struct {
 	APIURL              string `json:"apiurl"`
 	Type                string `json:"type"`
 	AuthType            string `json:"auth_type"`
+	AuthToken           string `json:"auth_token"`
 	SkipVerify          bool   `json:"skip_verify"`
 	Oauth2ClientID      string `json:"oauth_2_client_id"`
 	Oauth2ClientSecret  string `json:"oauth_2_client_secret"`


### PR DESCRIPTION
So we can use user's personal token to register and authenticate without
browser. Adding remotesource command:

	agola --token "admintoken" --gateway-url http://127.0.0.1:8000 remotesource create \                                                                                                                                                        gitchai/git/feature/agola !
	  --name gitea \
	  --type gitea \
	  --api-url http://192.168.64.21 \
	  --auth-type token \
	  --auth-token 122b1c7df3c45fe94083d2cb8250c310c4fc0713 \
	  --skip-ssh-host-key-check